### PR TITLE
fix: use reactive rendering to prevent re-mounting gosling component

### DIFF
--- a/front/src/components/Gosling.tsx
+++ b/front/src/components/Gosling.tsx
@@ -142,7 +142,6 @@ export default class GoslingVis extends React.Component<Props, {}> {
 
     const spec = {
       title: '',
-      responsiveSize: { width: true },
       width: width - cardPadding * 2,
       height: height - cardPadding * 2 - cardHeadHeight - 24, // gosling vis axis: 24px
       tracks: [...(dataset == 'sequence' ? [PeakTrack] : [MatrixTrack, CTCFTrack]), labelTrack]


### PR DESCRIPTION
This PR uses experimental `reactive` rendering in Gosling to prevent re-mounting gosling components upon filtering samples. This fixes an issue that, whenever users filter samples, they can see a white empty space since the gosling component is unmounted and then mounted again.