### PR TITLE
feat: add LanceOtron annotation columns

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -174,6 +174,8 @@ export default class App extends React.Component<{}, State> {
           'ctcf_mean',
           'ctcf_left',
           'ctcf_right',
+          'Peak Score (LanceOtron)',
+          'Peak Area (LanceOtron)',
           'atac_mean',
           'atac_left',
           'atac_right'


### PR DESCRIPTION
Added two annotation columns that are based on LanceOtron (https://lanceotron.molbiol.ox.ac.uk/). Added those to `results_chr1-5_10k_onTad.csv`, i.e.:

- 'Peak Score (LanceOtron)'
- 'Peak Area (LanceOtron)'

I've manually extracted the annotations using the LanceOtron website and then added the columns that LanceOtron generated to our file.

I was not sure what would be the best approach to add columns that are generated outside of the project since AFAIU running `add_col.py` will remove these two columns from `results_chr1-5_10k_onTad.csv`.

**A file that needs to be updated:** [public/assets/results_chr1-5_10k_onTad.csv](https://github.com/wangqianwen0418/DRAVA/files/8154907/results_chr1-5_10k_onTad.csv)

(Observable: https://observablehq.com/d/5ff70786781809e4)


![Screen Shot 2022-02-28 at 11 20 59](https://user-images.githubusercontent.com/9922882/156019959-e57eade6-d10b-4a0c-8a61-f459fd7c9564.png)


LanceOtron analysis page:
![Screen Shot 2022-02-28 at 11 38 00](https://user-images.githubusercontent.com/9922882/156021961-421c46e1-1161-4600-be35-54c4fe3f1264.png)

