### PR TITLE
Qianwen/dataset config

### DIFF
--- a/front/src/config/dataset_config.ts
+++ b/front/src/config/dataset_config.ts
@@ -1,0 +1,68 @@
+type viewName = 'latentDim' | 'gosling' | 'itemView' | 'contextView';
+type TDatasetConfig = {
+  [key: string]: {
+    name: string;
+    labels: string[];
+    customDims: string[];
+    views: { left: viewName[]; right: viewName[] };
+  };
+};
+
+const datasetConfig: TDatasetConfig = {
+  matrix: {
+    name: 'Matrix',
+    labels: [],
+    customDims: [
+      'size',
+      'score',
+      'ctcf_mean',
+      'ctcf_left',
+      'ctcf_right',
+      'atac_mean',
+      'atac_left',
+      'atac_right',
+      'recons_loss'
+    ],
+    views: { left: ['latentDim', 'gosling'], right: ['itemView'] }
+  },
+  celeb: {
+    name: 'CelebA',
+    labels: ['gender', 'smiling', 'hair', 'bangs', 'young'],
+    customDims: ['recons_loss'],
+    views: { left: ['latentDim'], right: ['itemView'] }
+  },
+  // sequence: {
+  //   name: 'Genomic Sequence',
+  //   labels: [],
+  //   customDims: ['peak_score', 'recons_loss'],
+  //   views: { left: ['latentDim', 'gosling'], right: ['itemView'] }
+  // },
+  IDC: {
+    name: 'Breaset Cancer',
+    labels: ['label', 'confidence', 'prediction'],
+    customDims: ['label', 'confidence', 'prediction', 'recons_loss'],
+    views: { left: ['latentDim', 'contextView'], right: ['itemView'] }
+  },
+  dsprites: {
+    name: 'Shapes',
+    labels: [],
+    customDims: ['recons_loss'],
+    views: { left: ['latentDim'], right: ['itemView'] }
+  },
+  sc2: {
+    name: 'Single Cell',
+    labels: [
+      'K-Means [Mean] Expression',
+      'K-Means [Covariance] Expression',
+      'K-Means [Total] Expression',
+      'K-Means [Mean-All-SubRegions] Expression',
+      'K-Means [Shape-Vectors]',
+      'K-Means [Texture]',
+      'K-Means [tSNE_All_Features]'
+    ],
+    customDims: ['recons_loss'],
+    views: { left: ['latentDim'], right: ['itemView'] }
+  }
+};
+
+export { datasetConfig };

--- a/front/src/config/index.ts
+++ b/front/src/config/index.ts
@@ -1,0 +1,1 @@
+export { datasetConfig } from './dataset_config';

--- a/server/flask_server/api.py
+++ b/server/flask_server/api.py
@@ -298,7 +298,7 @@ def get_simu_images():
         if dataset == 'matrix':  # changef from grayscale to a defined color map
             res = colormap.get_cmap('viridis')(res) * 255
             pil_img = Image.fromarray(res.astype(np.uint8)).convert('RGB')
-        if dataset == 'sc2':
+        elif dataset == 'sc2':
             pil_img = cate_arr_to_image(res)
         else:
             if (dataset) == 'dsprites':


### PR DESCRIPTION
the front-end for different datasets are now configured using the `front/src/config/dataset_config.ts`
```javascript
type viewName = 'latentDim' | 'gosling' | 'itemView' | 'contextView';
type TDatasetConfig = {
  [key: string]: {
    name: string; // dataset name shown in the side menu
    labels: string[]; // item labels used in the item browser
    customDims: string[]; // user-defined dimensions will be added into the latentDim view
    views: { left: viewName[]; right: viewName[] }; // configure the view composition
  };
};
```